### PR TITLE
fix: prevent extra audio resets by cleaning effect deps

### DIFF
--- a/app/common/components/audio-player.tsx
+++ b/app/common/components/audio-player.tsx
@@ -56,7 +56,7 @@ export default function AudioPlayer() {
     audioRef.current.currentTime = 0;
     audioRef.current.src = currentTrack.audioUrl;
     audioRef.current.load();
-  }, [audioRef.current, currentTrack]);
+  }, [currentTrack]);
 
   useEffect(() => {
     if (!audioRef.current) {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Remove `audioRef.current` from useEffect dependency array

- Prevent unnecessary audio resets and re-renders


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["useEffect with audioRef.current dependency"] --> B["Unnecessary re-renders"]
  C["Remove audioRef.current from deps"] --> D["Stable effect execution"]
  A --> C
  B --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>audio-player.tsx</strong><dd><code>Clean useEffect dependencies in audio player</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/common/components/audio-player.tsx

<ul><li>Remove <code>audioRef.current</code> from useEffect dependency array<br> <li> Keep only <code>currentTrack</code> as dependency for audio reset logic</ul>


</details>


  </td>
  <td><a href="https://github.com/hubiwibe/tech-song/pull/3/files#diff-2fd46886d1f36540a62ba44a20c7622781abbc7ab9f2ecb72cfcc39bdd4407c9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 오디오 플레이어에서 트랙 변경 시 오디오가 올바르게 초기화되도록 동작이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->