### PR TITLE
feat: add copilot instructions for English and Korean translations

### DIFF
--- a/github/copilot-instructions.md
+++ b/github/copilot-instructions.md
@@ -1,0 +1,1 @@
+Please make sure to create your answer in English, then translate it into Korean and leave a PR review.

--- a/github/copilot-instructions.md
+++ b/github/copilot-instructions.md
@@ -1,1 +1,5 @@
-Please make sure to create your answer in English, then translate it into Korean and leave a PR review.
+Follow these steps to complete the task:
+1. Generate your initial response in English. "Your answer" refers to the response you create based on the task requirements.
+2. Translate your English response into Korean.
+3. Submit both the English and Korean versions as a PR review comment.
+This workflow should be applied whenever you are tasked with providing a bilingual response for a pull request review.


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Add GitHub Copilot instructions for bilingual PR reviews


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Repository"] --> B["Copilot Instructions"]
  B --> C["English Response"]
  C --> D["Korean Translation"]
  D --> E["PR Review"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>copilot-instructions.md</strong><dd><code>Add bilingual Copilot instructions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

github/copilot-instructions.md

<ul><li>Create new Copilot instructions file<br> <li> Define bilingual workflow for English and Korean<br> <li> Specify PR review translation requirements</ul>


</details>


  </td>
  <td><a href="https://github.com/hubiwibe/tech-song/pull/9/files#diff-30d9c62b100541f57460c95106a144dd73d9849000d1614da4941851e4e4c0af">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

